### PR TITLE
2020 24 Load balancer

### DIFF
--- a/marketplace/pyramid-add-to-central-instance.yaml
+++ b/marketplace/pyramid-add-to-central-instance.yaml
@@ -250,12 +250,19 @@ Conditions:
     - !Equals
       - !Ref AssignPublicIP
       - 'true'
+  LoadBalancer:  !And
+    - !Condition WebAccess
+    - !Not
+      - !Equals
+        - !Sub '{{resolve:ssm:/Pyramid/${BaseStackName}/LoadBalancer:1}}'
+        - ''
+
 
 Resources:
   LaunchInstance:
     Type: 'AWS::CloudFormation::Stack'
     Properties:
-      TemplateURL: https://pyramid-cloudformation.s3.amazonaws.com/marketplace/2020-24/pyramid-single-instance.yaml
+      TemplateURL: https://pyramid-cloudformation.s3.amazonaws.com/marketplace/2020-24-lb/pyramid-single-instance.yaml
       Parameters:
         BaseStackName: !Ref BaseStackName
         AMIID: !FindInMap 
@@ -286,6 +293,14 @@ Resources:
 
         RepositoryType: currentremote
 
+  ManageTargets:
+    Type: 'Custom::ManageTargetsLambda'
+    Condition: LoadBalancer
+    Properties:
+      ServiceToken: !Sub '{{resolve:ssm:/Pyramid/${BaseStackName}/ManageTargetsLambdaArn:1}}'
+      TargetGroupArn: !Sub '{{resolve:ssm:/Pyramid/${BaseStackName}/WebTargetGroup:1}}'
+      InstanceId: !GetAtt LaunchInstance.Outputs.InstanceId
+      
 Outputs:
   PyramidPublicURL:
     Value: !If

--- a/marketplace/pyramid-backup-restore-s3.yaml
+++ b/marketplace/pyramid-backup-restore-s3.yaml
@@ -854,7 +854,7 @@ Resources:
                     #   Z34PQSL3TPJI7P  False   False   arn:aws:kms:af-south-1:99999:key/aaa-aaa-aaa-aaa    2022-06-16T13:37:28.956Z        
                     #   userid True    5432    04:59-05:29     tue:04:05-tue:04:35  aaa-aaa-aaa-aaa.cluster-ro-cml8vdx48kqh.af-south-1.rds.amazonaws.com   available       True
 
-                    postgresVersion=`echo $cluster | cut -d ' ' -f 19`
+                    postgresVersion=`echo $cluster | cut -d ' ' -f 20`
                   fi
 
                   # get major version and tool package name

--- a/marketplace/pyramid-base-resources-parameters.yaml
+++ b/marketplace/pyramid-base-resources-parameters.yaml
@@ -793,6 +793,7 @@ Resources:
         Vendor: Pyramid
 
   LoadBalancerAccessSecurityGroupSSM:
+    Condition: ImplementLoadBalancer
     Type: AWS::SSM::Parameter
     Properties:
       Name: !Sub '/Pyramid/${BaseStackName}/LoadBalancerAccessSecurityGroup'

--- a/marketplace/pyramid-base-resources-parameters.yaml
+++ b/marketplace/pyramid-base-resources-parameters.yaml
@@ -22,6 +22,10 @@ Metadata:
           default: File System
         Parameters:
           - ExistingFileSystemId
+      - Label:
+          default: Load Balancer
+        Parameters:
+          - ImplementLoadBalancer
     ParameterLabels:
       BaseStackName:
         default: Base Stack Name
@@ -41,6 +45,9 @@ Metadata:
         default: File upload size setting for nginx web server (MB)
       ExistingFileSystemId:
         default: Existing File system Id
+      ImplementLoadBalancer:
+        default: Implement Load Balancer
+
 Parameters:
   BaseStackName:
     Description: Base Stack Name
@@ -110,16 +117,16 @@ Parameters:
       - true
       - false
     ConstraintDescription: Required
-  HTTPAccessCIDR:
-    AllowedPattern: >-
-      ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
-    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/x
-    Description: >-
-      Allowed CIDR block for HTTP and HTTPS traffic. Please set CIDR to
-      x.x.x.x/32 to allow one specific IP address access, 0.0.0.0/0 to allow all
-      IP addresses access, or another CIDR range.
-    Type: String
-    MinLength: '9'
+  # HTTPAccessCIDR:
+  #   AllowedPattern: >-
+  #     ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
+  #   ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/x
+  #   Description: >-
+  #     Allowed CIDR block for HTTP and HTTPS traffic. Please set CIDR to
+  #     x.x.x.x/32 to allow one specific IP address access, 0.0.0.0/0 to allow all
+  #     IP addresses access, or another CIDR range.
+  #   Type: String
+  #   MinLength: '9'
   AllowSSHSecurityGroup:
     Description: >-
       Optional. ID of the security group (e.g. sg-0fec99734449e8888) to allow SSH access into the instance ie. Bastion
@@ -165,6 +172,16 @@ Parameters:
     AllowedPattern: '^$|fs-[a-f0-9]{8}'
     ConstraintDescription: >-
       Optional. EFS ID like fs-9554b161.
+  ImplementLoadBalancer:
+    Description: >-
+      Implement Load Balancer
+    Type: String
+    Default: false
+    AllowedValues:
+      - true
+      - false
+      - trueHTTPS
+    ConstraintDescription: Required
 
 Rules:
   KeyPairsNotEmpty:
@@ -185,6 +202,19 @@ Conditions:
     - ''
   ReuseExistingFileSystem: !Not 
     - !Condition CreateFileSystem
+  DontImplementLoadBalancer: !Equals
+    - !Ref ImplementLoadBalancer
+    - false
+  ImplementLoadBalancer: !Not
+    - !Equals
+      - !Ref ImplementLoadBalancer
+      - false
+  ImplementHTTPOnlyonLB: !Equals
+    - !Ref ImplementLoadBalancer
+    - true
+  ImplementHTTPSonLB: !Equals
+    - !Ref ImplementLoadBalancer
+    - trueHTTPS
 
 Resources:
 
@@ -289,7 +319,30 @@ Resources:
   WebAccessSecurityGroup:
     Type: 'AWS::EC2::SecurityGroup'
     Properties:
-      GroupDescription: Allow HTTP and HTTPS access to the instance
+      GroupDescription: Allow HTTP access to the Pyramid Web server processes
+      VpcId: !Ref VPCID
+      SecurityGroupEgress:
+        - IpProtocol: '-1'
+          FromPort: -1
+          ToPort: -1
+          CidrIp: 0.0.0.0/0
+
+  # Not implementing LB: allow direct access to instance
+  LoadBalancerToWebAccessIngress:
+    Type: 'AWS::EC2::SecurityGroupIngress'
+    Condition: DontImplementLoadBalancer
+    Properties:
+      GroupId: !GetAtt WebAccessSecurityGroup.GroupId
+      IpProtocol: tcp
+      FromPort: 80
+      ToPort: 80
+      CidrIp: !Ref HTTPAccessCIDR
+
+  LoadBalancerAccessSecurityGroup:
+    Type: 'AWS::EC2::SecurityGroup'
+    Condition: ImplementLoadBalancer
+    Properties:
+      GroupDescription: Allow HTTP to the load balancer
       VpcId: !Ref VPCID
       SecurityGroupEgress:
         - IpProtocol: '-1'
@@ -301,10 +354,29 @@ Resources:
           FromPort: 80
           ToPort: 80
           CidrIp: !Ref HTTPAccessCIDR
-        - IpProtocol: tcp
-          FromPort: 443
-          ToPort: 443
-          CidrIp: !Ref HTTPAccessCIDR
+
+  HTTPSLoadBalancerIngress:
+    Type: 'AWS::EC2::SecurityGroupIngress'
+    Condition: ImplementHTTPSonLB
+    Properties:
+      Description: Allow HTTPS into Load Balancer
+      GroupId: !GetAtt LoadBalancerAccessSecurityGroup.GroupId
+      IpProtocol: tcp
+      FromPort: 443
+      ToPort: 443
+      CidrIp: !Ref HTTPAccessCIDR
+
+  LoadBalancerToWebServerIngress:
+    Type: 'AWS::EC2::SecurityGroupIngress'
+    Condition: ImplementLoadBalancer
+    Properties:
+      Description: Allow Load Balancer traffic into Pyramid Web Server
+      GroupId: !GetAtt WebAccessSecurityGroup.GroupId
+      IpProtocol: tcp
+      FromPort: 80
+      ToPort: 80
+      SourceSecurityGroupId: !Ref LoadBalancerAccessSecurityGroup
+
 
   PyramidProcessesSecurityGroup:
     Type: 'AWS::EC2::SecurityGroup'
@@ -316,6 +388,7 @@ Resources:
           FromPort: -1
           ToPort: -1
           CidrIp: 0.0.0.0/0
+  
   SSHIngress:
     Type: 'AWS::EC2::SecurityGroupIngress'
     Condition: AllowSSH
@@ -325,6 +398,7 @@ Resources:
       FromPort: 22
       ToPort: 22
       SourceSecurityGroupId: !Ref AllowSSHSecurityGroup
+
   PyramidProcessesSecurityGroupInternalIngress:
     Type: 'AWS::EC2::SecurityGroupIngress'
     Properties:
@@ -333,6 +407,7 @@ Resources:
       FromPort: 12100
       ToPort: 12200
       SourceSecurityGroupId: !GetAtt PyramidProcessesSecurityGroup.GroupId
+
   PyramidProcessesSecurityGroupInternalIngressForWebServer:
     Type: 'AWS::EC2::SecurityGroupIngress'
     Properties:
@@ -713,6 +788,17 @@ Resources:
       Type: String
       Value: !Ref WebAccessSecurityGroup
       Description: Security group for web access to instances
+      Tags:
+        StackName: !Sub '${BaseStackName}'
+        Vendor: Pyramid
+
+  LoadBalancerAccessSecurityGroupSSM:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub '/Pyramid/${BaseStackName}/LoadBalancerAccessSecurityGroup'
+      Type: String
+      Value: !Ref LoadBalancerAccessSecurityGroup
+      Description: Security group for web access to load balancer
       Tags:
         StackName: !Sub '${BaseStackName}'
         Vendor: Pyramid

--- a/marketplace/pyramid-central-instance-existing-repository.yaml
+++ b/marketplace/pyramid-central-instance-existing-repository.yaml
@@ -31,6 +31,13 @@ Metadata:
           - RDSName
           - RDSSecurityGroup
       - Label:
+          default: New Load Balancer
+        Parameters:
+          - CreateLoadBalancer
+          - LoadBalancerSubnets
+          - LoadBalancerInternetFacing
+          - CertificateArn
+      - Label:
           default: Repository and file system initialization
         Parameters:
           - BackupS3Bucket
@@ -76,6 +83,14 @@ Metadata:
         default: Initial Pyramid User password
       FileUploadSize:
         default: File upload size setting for nginx web server (MB)
+      CreateLoadBalancer:
+        default: Create Load Balancer?
+      LoadBalancerSubnets: 
+        default: Subnets for Load Balancer
+      LoadBalancerInternetFacing:
+        default: Is the load balancer exposed to the public internet?
+      CertificateArn:
+        default: ARN for SSL certificate
       BackupS3Bucket:
         default: S3 bucket containing a Pyramid backup
       BackupS3Folder:
@@ -254,6 +269,28 @@ Parameters:
     Default: 200
     MinValue: 200
     ConstraintDescription: Must be more than 200 (MB).
+  CreateLoadBalancer:
+    Description: Create Load Balancer?
+    Type: String
+    Default: false
+    AllowedValues:
+      - true
+      - false
+  LoadBalancerSubnets: 
+    Description: Subnets for Load Balancer
+    Type: 'List<AWS::EC2::Subnet::Id>'
+  LoadBalancerInternetFacing:
+    Description: >-
+      Load Balancer is exposed to public Internet
+    Type: String
+    Default: true
+    AllowedValues:
+      - true
+      - false
+  CertificateArn:
+    Description: 'Certificate Manager ARN for SSL certificate, of the form: arn:aws:acm:<region>:<AWS account id>:certificate/<certificate id GUID>'
+    Type: String
+    AllowedPattern: '^arn:aws:acm:[a-z]{2}-[a-z]{4,}-\d{1,}:\d{12}:certificate/[-a-z0-9]{36}'
   BackupS3Bucket:
     Description: >-
       S3 bucket to a Pyramid backup
@@ -362,6 +399,9 @@ Conditions:
     - !Equals
       - !Ref InitializeRepository
       - 'false'
+  CreateLB: !Equals
+    - !Ref CreateLoadBalancer
+    - 'true'
 
 
 Resources:
@@ -370,7 +410,7 @@ Resources:
     Type: 'AWS::CloudFormation::Stack'
     Properties:
       TemplateURL: >-
-        https://pyramid-cloudformation.s3.amazonaws.com/marketplace/2020-24/pyramid-base-resources-parameters.yaml
+        https://pyramid-cloudformation.s3.amazonaws.com/marketplace/2020-24-lb/pyramid-base-resources-parameters.yaml
       Parameters:
         BaseStackName: !Ref AWS::StackName
         VPCID: !Ref VPCID
@@ -496,7 +536,7 @@ Resources:
       - PyramidProcessesSecurityGroupRepositoryAccess
     Properties:
       TemplateURL: >-
-        https://pyramid-cloudformation.s3.amazonaws.com/marketplace/2020-24/pyramid-backup-restore-s3.yaml
+        https://pyramid-cloudformation.s3.amazonaws.com/marketplace/2020-24-lb/pyramid-backup-restore-s3.yaml
       Parameters:
         BackupRestore: restore
         BaseStackName: !Ref AWS::StackName
@@ -510,7 +550,7 @@ Resources:
       - PyramidProcessesSecurityGroupRepositoryAccess
     Properties:
       TemplateURL: >-
-        https://pyramid-cloudformation.s3.amazonaws.com/marketplace/2020-24/pyramid-single-instance.yaml
+        https://pyramid-cloudformation.s3.amazonaws.com/marketplace/2020-24-lb/pyramid-single-instance.yaml
       Parameters:
         AMIID: !FindInMap 
           - AWSAMIRegionMap
@@ -537,6 +577,23 @@ Resources:
           - RestoreFromBackup
           - !GetAtt RestoreBackup.Outputs.BackupBucket
           - No backup
+
+
+  LoadBalancer:
+    Type: 'AWS::CloudFormation::Stack'
+    Condition: CreateLB
+    Properties:
+      TemplateURL: >-
+        https://pyramid-cloudformation.s3.amazonaws.com/marketplace/2020-24-lb/pyramid-load-balancer.yaml
+      Parameters:
+        BaseStackName: !Ref AWS::StackName
+        WebInstance: !Ref CentralInstance
+        VPCID: !Ref VPCID
+        LoadBalancerSubnetIds: !Join 
+          - ','
+          - !Ref LoadBalancerSubnets
+        LoadBalancerInternetFacing: !Ref LoadBalancerInternetFacing
+        CertificateArn: !Ref CertificateArn
 
 Outputs:
   PyramidPublicURL:

--- a/marketplace/pyramid-central-instance-existing-repository.yaml
+++ b/marketplace/pyramid-central-instance-existing-repository.yaml
@@ -31,13 +31,6 @@ Metadata:
           - RDSName
           - RDSSecurityGroup
       - Label:
-          default: New Load Balancer
-        Parameters:
-          - CreateLoadBalancer
-          - LoadBalancerSubnets
-          - LoadBalancerInternetFacing
-          - CertificateArn
-      - Label:
           default: Repository and file system initialization
         Parameters:
           - BackupS3Bucket
@@ -83,14 +76,6 @@ Metadata:
         default: Initial Pyramid User password
       FileUploadSize:
         default: File upload size setting for nginx web server (MB)
-      CreateLoadBalancer:
-        default: Create Load Balancer?
-      LoadBalancerSubnets: 
-        default: Subnets for Load Balancer
-      LoadBalancerInternetFacing:
-        default: Is the load balancer exposed to the public internet?
-      CertificateArn:
-        default: ARN for SSL certificate
       BackupS3Bucket:
         default: S3 bucket containing a Pyramid backup
       BackupS3Folder:
@@ -269,28 +254,6 @@ Parameters:
     Default: 200
     MinValue: 200
     ConstraintDescription: Must be more than 200 (MB).
-  CreateLoadBalancer:
-    Description: Create Load Balancer?
-    Type: String
-    Default: false
-    AllowedValues:
-      - true
-      - false
-  LoadBalancerSubnets: 
-    Description: Subnets for Load Balancer
-    Type: 'List<AWS::EC2::Subnet::Id>'
-  LoadBalancerInternetFacing:
-    Description: >-
-      Load Balancer is exposed to public Internet
-    Type: String
-    Default: true
-    AllowedValues:
-      - true
-      - false
-  CertificateArn:
-    Description: 'Certificate Manager ARN for SSL certificate, of the form: arn:aws:acm:<region>:<AWS account id>:certificate/<certificate id GUID>'
-    Type: String
-    AllowedPattern: '^$|^arn:aws:acm:[a-z]{2}-[a-z]{4,}-\d{1,}:\d{12}:certificate/[-a-z0-9]{36}'
   BackupS3Bucket:
     Description: >-
       S3 bucket to a Pyramid backup
@@ -399,9 +362,6 @@ Conditions:
     - !Equals
       - !Ref InitializeRepository
       - 'false'
-  CreateLB: !Equals
-    - !Ref CreateLoadBalancer
-    - 'true'
 
 
 Resources:
@@ -577,23 +537,6 @@ Resources:
           - RestoreFromBackup
           - !GetAtt RestoreBackup.Outputs.BackupBucket
           - No backup
-
-
-  LoadBalancer:
-    Type: 'AWS::CloudFormation::Stack'
-    Condition: CreateLB
-    Properties:
-      TemplateURL: >-
-        https://pyramid-cloudformation.s3.amazonaws.com/marketplace/2020-24-lb/pyramid-load-balancer.yaml
-      Parameters:
-        BaseStackName: !Ref AWS::StackName
-        WebInstance: !Ref CentralInstance
-        VPCID: !Ref VPCID
-        LoadBalancerSubnetIds: !Join 
-          - ','
-          - !Ref LoadBalancerSubnets
-        LoadBalancerInternetFacing: !Ref LoadBalancerInternetFacing
-        CertificateArn: !Ref CertificateArn
 
 Outputs:
   PyramidPublicURL:

--- a/marketplace/pyramid-central-instance-load-balancer-existing-repository.yaml
+++ b/marketplace/pyramid-central-instance-load-balancer-existing-repository.yaml
@@ -14,8 +14,6 @@ Metadata:
           - Subnet
           - InstanceType
           - KeyPairName
-          - AssignPublicIP
-          - HTTPAccessCIDR
           - AllowSSHSecurityGroup
           - InitialUsername
           - InitialUserPassword
@@ -33,6 +31,7 @@ Metadata:
       - Label:
           default: New Load Balancer
         Parameters:
+          - HTTPAccessCIDR
           - LoadBalancerSubnets
           - LoadBalancerInternetFacing
           - CertificateArn
@@ -52,8 +51,6 @@ Metadata:
         default: Subnet for Pyramid instance
       InstanceType:
         default: Instance type
-      AssignPublicIP:
-        default: Assign public IP and domain name
       HTTPAccessCIDR:
         default: HTTP/HTTPS CIDR
       AllowSSHSecurityGroup:
@@ -138,15 +135,6 @@ Parameters:
       - c5n.12xlarge
     Default: c5.4xlarge
     ConstraintDescription: Must be a valid instance type for region.
-  AssignPublicIP:
-    Description: >-
-      Assign public IP address and domain.
-    Type: String
-    Default: true
-    AllowedValues:
-      - true
-      - false
-    ConstraintDescription: Required
   HTTPAccessCIDR:
     AllowedPattern: >-
       ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
@@ -377,9 +365,6 @@ Conditions:
   DatabaseTypeIsMicrosoft: !Equals
     - !Ref RDSDeploymentType
     - 'MicrosoftSQLServer'
-  PublicIP: !Equals
-    - !Ref AssignPublicIP
-    - 'true'
   RestoreFromBackup: !Not 
     - !Equals 
       - !Ref BackupS3Bucket
@@ -561,7 +546,7 @@ Resources:
             - !GetAtt BaseResourcesParameters.Outputs.PyramidProcessesSecurityGroup
             - !GetAtt BaseResourcesParameters.Outputs.MountTargetSecurityGroup
         Subnet: !Ref Subnet
-        AssignPublicIP: !Ref AssignPublicIP
+        AssignPublicIP: false
         InstallProxy: true
         RepositoryType: !If
           - DontInitializeRepository

--- a/marketplace/pyramid-central-instance-load-balancer-existing-repository.yaml
+++ b/marketplace/pyramid-central-instance-load-balancer-existing-repository.yaml
@@ -1,9 +1,9 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: >-
-  Deploys a single instance of Pyramid 2020 with all services and a new Aurora
-  Postgres cluster for the repository database. Option to restore from a Pyramid backup.
-  To be deployed in a public subnet, as the Pyramid web server is available on port 80.
-  You will be billed for the AWS resources used if you create a stack from this template. 
+  Deploys a single instance of Pyramid 2020 with all services and a new RDS 
+  instance for the repository database. To be deployed in a public
+  subnet, as the Pyramid web server is available on port 80. You will be billed
+  for the AWS resources used if you create a stack from this template. 
 Metadata:
   'AWS::CloudFormation::Interface':
     ParameterGroups:
@@ -21,14 +21,15 @@ Metadata:
           - InitialUserPassword
           - FileUploadSize
       - Label:
-          default: New Repository Database Service
+          default: Existing Repository Database Service and File system
         Parameters:
           - RDSDeploymentType
-          - RDSServiceName
-          - NewRDSSubnets
-          - RDSUser
+          - RDSAddress
+          - RDSPort
+          - RDSUsername
           - RDSPassword
           - RDSName
+          - RDSSecurityGroup
       - Label:
           default: New Load Balancer
         Parameters:
@@ -36,10 +37,12 @@ Metadata:
           - LoadBalancerInternetFacing
           - CertificateArn
       - Label:
-          default: Pyramid S3 backup to restore from
+          default: Repository and file system initialization
         Parameters:
           - BackupS3Bucket
           - BackupS3Folder
+          - InitializeRepository
+          - ExistingFileSystemId
     ParameterLabels:
       KeyPairName:
         default: Key pair name
@@ -56,24 +59,29 @@ Metadata:
       AllowSSHSecurityGroup:
         default: SSH Security Group ID
       RDSDeploymentType:
-        default: RDS Deployment type
-      RDSServiceName:
-        default: New RDS service name
-      NewRDSSubnets:
-        default: >-
-          New RDS service subnets
-      RDSUser:
+        default: Database type
+      RDSAddress:
+        default: Existing RDS domain name
+      RDSPort:
+        default: RDS database port
+      RDSUsername:
         default: RDS database user name
       RDSPassword:
         default: RDS database password
       RDSName:
         default: Repository database name
-      FileUploadSize:
-        default: File upload size setting for nginx web server (MB)
+      RDSSecurityGroup:
+        default: Security group for access to Repository database service
+      ExistingFileSystemId:
+        default: Existing File system Id if not initializing or restoring
+      InitializeRepository:
+        default: Initialize Repository database?
       InitialUsername:
         default: Initial Pyramid user name
       InitialUserPassword:
         default: Initial Pyramid User password
+      FileUploadSize:
+        default: File upload size setting for nginx web server (MB)
       LoadBalancerSubnets: 
         default: Subnets for Load Balancer
       LoadBalancerInternetFacing:
@@ -158,29 +166,22 @@ Parameters:
     MaxLength: '128'
     AllowedPattern: '^$|sg-[a-f0-9]{6,17}$'
   RDSDeploymentType:
-    Description: RDS deployment type
+    Description: Database type
     Type: String
-    Default: PostgreSQLAuroraServerless
+    Default: PostgreSQL
     AllowedValues:
-      - PostgreSQLAuroraServerless
-      - PostgreSQLAuroraProvisioned
       - PostgreSQL
       - MicrosoftSQLServer
-  RDSServiceName:
+  RDSAddress:
     Description: >-
-      Name of the new RDS service (ie. pyramid)
+      Domain name of exisitng RDS service (ie. pyramid.cluster-cfave2vnma46.us-east-1.rds.amazonaws.com)
     Type: String
     MinLength: '5'
     MaxLength: '128'
-    AllowedPattern: '[a-zA-Z][-a-zA-Z0-9]*'
+    AllowedPattern: '[a-zA-Z][-_a-zA-Z0-9\.]*'
     ConstraintDescription: >-
-      Min 5 characters. First character must be a letter. Must contain only letters, digits or '-'.
-  NewRDSSubnets:
-    Description: Subnets to deploy the new RDS cluster into.  At least 2 must be entered, even when using existing
-          service.
-    Type: 'List<AWS::EC2::Subnet::Id>'
-    ConstraintDescription: Required
-  RDSUser:
+      Min 5 characters. First character must be a letter. Must contain only letters, digits, '.', '-' or underscores.
+  RDSUsername:
     Description: >-
       Master user name for the RDS database. Min 5 characters. It can contain
       only alphanumeric characters and underscores.
@@ -203,6 +204,11 @@ Parameters:
     ConstraintDescription: >-
       Min 8 characters. Can contain only alphanumeric characters, minus and
       underscores.
+  RDSPort:
+    Description: RDS Port. Standards are 5432 for PostgreSQL and 1433 for Microsft SQL Server.
+    Type: Number
+    MinValue: '1024'
+    ConstraintDescription: Port number must be higher than 1024
   RDSName:
     Description: Repository database name in the RDS service.
     Type: String
@@ -213,6 +219,24 @@ Parameters:
     ConstraintDescription: >-
       Min 6 characters. Must begin with a letter and contain only alphanumeric
       characters and underscores.
+  ExistingFileSystemId:
+    Description: >-
+      For reusing an existing file system for Pyramid combined with an existing repository database.
+    Type: String
+    Default: ''
+    AllowedPattern: '^$|fs-[a-f0-9]{8}'
+    ConstraintDescription: >-
+      Optional. EFS ID like fs-9554b161.
+  InitializeRepository:
+    Description: If not restoring from backup, initialize Pyramid Repository database name. false assumes database name exists
+    Type: String
+    Default: true
+    AllowedValues:
+      - true
+      - false
+  RDSSecurityGroup:
+    Description: Security Group for access into RDS service.
+    Type: 'AWS::EC2::SecurityGroup::Id'
   InitialUsername:
     ConstraintDescription: >-
       Min 5 characters. Must begin with a letter and contain only alphanumeric
@@ -257,7 +281,6 @@ Parameters:
     Description: 'Certificate Manager ARN for SSL certificate, of the form: arn:aws:acm:<region>:<AWS account id>:certificate/<certificate id GUID>'
     Type: String
     AllowedPattern: '^$|^arn:aws:acm:[a-z]{2}-[a-z]{4,}-\d{1,}:\d{12}:certificate/[-a-z0-9]{36}'
-
   BackupS3Bucket:
     Description: >-
       S3 bucket to a Pyramid backup
@@ -273,7 +296,7 @@ Parameters:
     Type: String
     Default: ''
     MaxLength: '1000'
-    AllowedPattern: '^$|^(?=^.{5,1000}$)[a-zA-Z0-9][-_a-zA-Z0-9/\=()+]*$'
+    AllowedPattern: '^$|^(?=^.{5,1000}$)[a-zA-Z0-9][-_a-zA-Z0-9\/\=()+]*$'
     ConstraintDescription: >-
       Optional. Otherwise min 5 characters. First character must be a letter or number. Must contain only letters, digits, '/', '-', '+', '_', '=' or parentheses.
 
@@ -325,7 +348,6 @@ Mappings:
     eu-south-1:
       '64': ami-015a7108facad1be3
 
-
 Rules:
   SubnetsNotEmpty:
     Assertions:
@@ -362,10 +384,16 @@ Conditions:
     - !Equals 
       - !Ref BackupS3Bucket
       - ''
+  DontInitializeRepository: !Or
+    - !Condition RestoreFromBackup
+    - !Equals
+      - !Ref InitializeRepository
+      - 'false'
   ImplementHTTPS: !Not
     - !Equals
       - !Ref CertificateArn
       - ''
+
 
 Resources:
 
@@ -382,41 +410,23 @@ Resources:
         AllowSSHSecurityGroup: !Ref AllowSSHSecurityGroup
         InitialUsername: !Ref InitialUsername
         InitialUserPassword: !Ref InitialUserPassword
+        ExistingFileSystemId: !If
+          - DontInitializeRepository
+          - !Ref ExistingFileSystemId
+          - !Ref AWS::NoValue
         FileUploadSize: !Ref FileUploadSize
         ImplementLoadBalancer: !If
           - ImplementHTTPS
           - trueHTTPS
           - true
 
-  CreateRepositoryDatabaseService:
-    Type: 'AWS::CloudFormation::Stack'
-    DeletionPolicy: Retain
-    UpdateReplacePolicy: Retain
-    DependsOn: BaseResourcesParameters
-    Properties:
-      TemplateURL: >-
-        https://pyramid-cloudformation.s3.amazonaws.com/marketplace/2020-24-lb/pyramid-repository-database.yaml
-      Parameters:
-        BaseStackName: !Ref AWS::StackName
-        RDSDeploymentType: !Ref RDSDeploymentType
-        VPCID: !Ref VPCID
-        SubnetIds: !Join 
-          - ','
-          - !Ref NewRDSSubnets
-        DBServiceName: !Ref RDSServiceName
-        DBMasterUsername: !Ref RDSUser
-        DBMasterUserPassword: !Ref RDSPassword
-
   RepositoryDatabaseTypeSSM:
     Type: AWS::SSM::Parameter
-    DependsOn: CreateRepositoryDatabaseService
+    DependsOn: BaseResourcesParameters
     Properties:
       Name: !Sub '/Pyramid/${AWS::StackName}/RepositoryDatabaseType'
       Type: String
-      Value: !If
-        - DatabaseTypeIsMicrosoft
-        - MicrosoftSQLServer
-        - PostgreSQL
+      Value: !Ref RDSDeploymentType
       Description: Database type for repository in RDS
       Tags:
         StackName: !Sub '${AWS::StackName}'
@@ -424,11 +434,11 @@ Resources:
 
   RepositoryDatabaseServiceNameSSM:
     Type: AWS::SSM::Parameter
-    DependsOn: CreateRepositoryDatabaseService
+    DependsOn: BaseResourcesParameters
     Properties:
       Name: !Sub '/Pyramid/${AWS::StackName}/RepositoryDatabaseServiceName'
       Type: String
-      Value: !Ref RDSServiceName
+      Value:  !Select [ 0, !Split [ ".", !Ref RDSAddress ]]
       Description: RDS service name of repository
       Tags:
         StackName: !Sub '${AWS::StackName}'
@@ -439,7 +449,7 @@ Resources:
     Properties:
       Name: !Sub '/Pyramid/${AWS::StackName}/RepositoryDatabaseAddress'
       Type: String
-      Value: !GetAtt CreateRepositoryDatabaseService.Outputs.RDSEndPointAddress
+      Value: !Ref RDSAddress
       Description: RDS domain of repository
       Tags:
         StackName: !Sub '${AWS::StackName}'
@@ -450,7 +460,7 @@ Resources:
     Properties:
       Name: !Sub '/Pyramid/${AWS::StackName}/RepositoryDatabasePort'
       Type: String
-      Value: !GetAtt CreateRepositoryDatabaseService.Outputs.RDSEndPointPort
+      Value: !Ref RDSPort
       Description: Port for repository in RDS
       Tags:
         StackName: !Sub '${AWS::StackName}'
@@ -461,7 +471,7 @@ Resources:
     Properties:
       Name: !Sub '/Pyramid/${AWS::StackName}/RepositoryDatabaseUsername'
       Type: String
-      Value: !GetAtt CreateRepositoryDatabaseService.Outputs.DBMasterUsername
+      Value: !Ref RDSUsername
       Description: User name for repository in RDS
       Tags:
         StackName: !Sub '${AWS::StackName}'
@@ -469,7 +479,7 @@ Resources:
 
   RDSPasswordSecret:
     Type: 'AWS::SecretsManager::Secret'
-    DependsOn: CreateRepositoryDatabaseService
+    DependsOn: BaseResourcesParameters
     Properties:
       Name: !Sub '/Pyramid/${AWS::StackName}/RepositoryDatabasePassword'
       Description: Password for RDS service
@@ -495,7 +505,7 @@ Resources:
 
   RepositoryDatabaseNameSSM:
     Type: AWS::SSM::Parameter
-    DependsOn: CreateRepositoryDatabaseService
+    DependsOn: BaseResourcesParameters
     Properties:
       Name: !Sub '/Pyramid/${AWS::StackName}/RepositoryDatabaseName'
       Type: String
@@ -505,24 +515,13 @@ Resources:
         StackName: !Sub '${AWS::StackName}'
         Vendor: Pyramid
 
-  RepositoryDatabaseEncryptionKeyARNSSM:
-    Type: AWS::SSM::Parameter
-    Properties:
-      Name: !Sub '/Pyramid/${AWS::StackName}/RepositoryDatabaseEncryptionKeyARN'
-      Type: String
-      Value: !GetAtt CreateRepositoryDatabaseService.Outputs.RDSEncryptionKeyARN
-      Description: Encryption key for Repository RDS Service
-      Tags:
-        StackName: !Sub '${AWS::StackName}'
-        Vendor: Pyramid
-
   PyramidProcessesSecurityGroupRepositoryAccess:
     Type: 'AWS::EC2::SecurityGroupIngress'
     Properties:
-      GroupId: !GetAtt CreateRepositoryDatabaseService.Outputs.RDSSecurityGroupId
+      GroupId: !Ref RDSSecurityGroup
       IpProtocol: tcp
-      FromPort: !GetAtt CreateRepositoryDatabaseService.Outputs.RDSEndPointPort
-      ToPort: !GetAtt CreateRepositoryDatabaseService.Outputs.RDSEndPointPort
+      FromPort: !Ref RDSPort
+      ToPort: !Ref RDSPort
       SourceSecurityGroupId: !GetAtt BaseResourcesParameters.Outputs.PyramidProcessesSecurityGroupId
 
   RestoreBackup:
@@ -565,7 +564,7 @@ Resources:
         AssignPublicIP: !Ref AssignPublicIP
         InstallProxy: true
         RepositoryType: !If
-          - RestoreFromBackup
+          - DontInitializeRepository
           - reuseremote
           - newremote
         #  Unused parameter. Only for dependency management in calling CFTs
@@ -574,6 +573,7 @@ Resources:
           - !GetAtt RestoreBackup.Outputs.BackupBucket
           - No backup
 
+
   LoadBalancer:
     Type: 'AWS::CloudFormation::Stack'
     Properties:
@@ -581,9 +581,9 @@ Resources:
         https://pyramid-cloudformation.s3.amazonaws.com/marketplace/2020-24-lb/pyramid-load-balancer.yaml
       Parameters:
         BaseStackName: !Ref AWS::StackName
-        WebInstance: !GetAtt CentralInstance.Outputs.InstanceId
+        WebInstance: !Ref CentralInstance
         VPCID: !Ref VPCID
-        LoadBalancerSubnets: !Join 
+        LoadBalancerSubnetIds: !Join 
           - ','
           - !Ref LoadBalancerSubnets
         LoadBalancerInternetFacing: !Ref LoadBalancerInternetFacing
@@ -592,6 +592,7 @@ Resources:
           - !Ref CertificateArn
           - ''
 
+
 Outputs:
   PyramidPublicURL:
     Value: !GetAtt LoadBalancer.Outputs.PyramidPublicURL
@@ -599,13 +600,14 @@ Outputs:
   PrivateDNSName:
     Value: !GetAtt LoadBalancer.Outputs.PrivateDNSName
     Description: Load balancer private DNS name
+
   VPC:
     Value: !Ref VPCID
     Description: VPC for deployment
   KeyPairName:
     Value: !Ref KeyPairName
     Description: Key Pair for instances
-
+    
   PyramidRole:
     Value: !GetAtt BaseResourcesParameters.Outputs.PyramidRole
     Description: IAM Role for instances launched from this stack
@@ -634,16 +636,16 @@ Outputs:
       - PostgreSQL
     Description: RDS Database type
   RepositoryDatabaseAddress:
-    Value: !GetAtt CreateRepositoryDatabaseService.Outputs.RDSEndPointAddress
+    Value: !Ref RDSAddress
     Description: Repository database address
   RepositoryDatabasePort:
-    Value: !GetAtt CreateRepositoryDatabaseService.Outputs.RDSEndPointPort
+    Value: !Ref RDSPort
     Description: Repository database port
   RepositoryDatabaseServiceName:
-    Value: !Ref RDSServiceName
+    Value: !Select [ 0, !Split [ ".", !Ref RDSAddress ]]
     Description: Repository database RDS Service name
   RepositoryDatabaseUsername:
-    Value: !Ref RDSUser
+    Value: !Ref RDSUsername
     Description: Repository database user name
   RepositoryDatabasePasswordARN:
     Value: !Ref RDSPasswordSecret
@@ -652,8 +654,5 @@ Outputs:
     Value: !Ref RDSName
     Description: Repository database schema name
   RDSSecurityGroup:
-    Value: !GetAtt CreateRepositoryDatabaseService.Outputs.RDSSecurityGroup
-    Description: Security Group access to repository
-  RDSEncryptionKeyARN:
-    Value: !GetAtt CreateRepositoryDatabaseService.Outputs.RDSEncryptionKeyARN
-    Description: Repository database encryption key ARN
+    Value: !Ref RDSSecurityGroup
+    Description: Security Group access to repository database

--- a/marketplace/pyramid-central-instance-load-balancer-new-repository.yaml
+++ b/marketplace/pyramid-central-instance-load-balancer-new-repository.yaml
@@ -14,8 +14,6 @@ Metadata:
           - Subnet
           - InstanceType
           - KeyPairName
-          - AssignPublicIP
-          - HTTPAccessCIDR
           - AllowSSHSecurityGroup
           - InitialUsername
           - InitialUserPassword
@@ -32,6 +30,7 @@ Metadata:
       - Label:
           default: New Load Balancer
         Parameters:
+          - HTTPAccessCIDR
           - LoadBalancerSubnets
           - LoadBalancerInternetFacing
           - CertificateArn
@@ -49,8 +48,6 @@ Metadata:
         default: Subnet for Pyramid instance
       InstanceType:
         default: Instance type
-      AssignPublicIP:
-        default: Assign public IP and domain name
       HTTPAccessCIDR:
         default: HTTP/HTTPS CIDR
       AllowSSHSecurityGroup:
@@ -130,15 +127,6 @@ Parameters:
       - c5n.12xlarge
     Default: c5.4xlarge
     ConstraintDescription: Must be a valid instance type for region.
-  AssignPublicIP:
-    Description: >-
-      Assign public IP address and domain.
-    Type: String
-    Default: true
-    AllowedValues:
-      - true
-      - false
-    ConstraintDescription: Required
   HTTPAccessCIDR:
     AllowedPattern: >-
       ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
@@ -355,9 +343,6 @@ Conditions:
   DatabaseTypeIsMicrosoft: !Equals
     - !Ref RDSDeploymentType
     - 'MicrosoftSQLServer'
-  PublicIP: !Equals
-    - !Ref AssignPublicIP
-    - 'true'
   RestoreFromBackup: !Not 
     - !Equals 
       - !Ref BackupS3Bucket
@@ -562,7 +547,7 @@ Resources:
             - !GetAtt BaseResourcesParameters.Outputs.PyramidProcessesSecurityGroup
             - !GetAtt BaseResourcesParameters.Outputs.MountTargetSecurityGroup
         Subnet: !Ref Subnet
-        AssignPublicIP: !Ref AssignPublicIP
+        AssignPublicIP: false
         InstallProxy: true
         RepositoryType: !If
           - RestoreFromBackup

--- a/marketplace/pyramid-central-instance-load-balancer-new-repository.yaml
+++ b/marketplace/pyramid-central-instance-load-balancer-new-repository.yaml
@@ -1,9 +1,9 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: >-
-  Deploys a single instance of Pyramid 2020 with all services and a new RDS 
-  instance for the repository database. To be deployed in a public
-  subnet, as the Pyramid web server is available on port 80. You will be billed
-  for the AWS resources used if you create a stack from this template. 
+  Deploys a single instance of Pyramid 2020 with all services and a new Aurora
+  Postgres cluster for the repository database. Option to restore from a Pyramid backup.
+  To be deployed in a public subnet, as the Pyramid web server is available on port 80.
+  You will be billed for the AWS resources used if you create a stack from this template. 
 Metadata:
   'AWS::CloudFormation::Interface':
     ParameterGroups:
@@ -21,29 +21,25 @@ Metadata:
           - InitialUserPassword
           - FileUploadSize
       - Label:
-          default: Existing Repository Database Service and File system
+          default: New Repository Database Service
         Parameters:
           - RDSDeploymentType
-          - RDSAddress
-          - RDSPort
-          - RDSUsername
+          - RDSServiceName
+          - NewRDSSubnets
+          - RDSUser
           - RDSPassword
           - RDSName
-          - RDSSecurityGroup
       - Label:
           default: New Load Balancer
         Parameters:
-          - CreateLoadBalancer
           - LoadBalancerSubnets
           - LoadBalancerInternetFacing
           - CertificateArn
       - Label:
-          default: Repository and file system initialization
+          default: Pyramid S3 backup to restore from
         Parameters:
           - BackupS3Bucket
           - BackupS3Folder
-          - InitializeRepository
-          - ExistingFileSystemId
     ParameterLabels:
       KeyPairName:
         default: Key pair name
@@ -60,31 +56,24 @@ Metadata:
       AllowSSHSecurityGroup:
         default: SSH Security Group ID
       RDSDeploymentType:
-        default: Database type
-      RDSAddress:
-        default: Existing RDS domain name
-      RDSPort:
-        default: RDS database port
-      RDSUsername:
+        default: RDS Deployment type
+      RDSServiceName:
+        default: New RDS service name
+      NewRDSSubnets:
+        default: >-
+          New RDS service subnets
+      RDSUser:
         default: RDS database user name
       RDSPassword:
         default: RDS database password
       RDSName:
         default: Repository database name
-      RDSSecurityGroup:
-        default: Security group for access to Repository database service
-      ExistingFileSystemId:
-        default: Existing File system Id if not initializing or restoring
-      InitializeRepository:
-        default: Initialize Repository database?
+      FileUploadSize:
+        default: File upload size setting for nginx web server (MB)
       InitialUsername:
         default: Initial Pyramid user name
       InitialUserPassword:
         default: Initial Pyramid User password
-      FileUploadSize:
-        default: File upload size setting for nginx web server (MB)
-      CreateLoadBalancer:
-        default: Create Load Balancer?
       LoadBalancerSubnets: 
         default: Subnets for Load Balancer
       LoadBalancerInternetFacing:
@@ -169,22 +158,29 @@ Parameters:
     MaxLength: '128'
     AllowedPattern: '^$|sg-[a-f0-9]{6,17}$'
   RDSDeploymentType:
-    Description: Database type
+    Description: RDS deployment type
     Type: String
-    Default: PostgreSQL
+    Default: PostgreSQLAuroraServerless
     AllowedValues:
+      - PostgreSQLAuroraServerless
+      - PostgreSQLAuroraProvisioned
       - PostgreSQL
       - MicrosoftSQLServer
-  RDSAddress:
+  RDSServiceName:
     Description: >-
-      Domain name of exisitng RDS service (ie. pyramid.cluster-cfave2vnma46.us-east-1.rds.amazonaws.com)
+      Name of the new RDS service (ie. pyramid)
     Type: String
     MinLength: '5'
     MaxLength: '128'
-    AllowedPattern: '[a-zA-Z][-_a-zA-Z0-9\.]*'
+    AllowedPattern: '[a-zA-Z][-a-zA-Z0-9]*'
     ConstraintDescription: >-
-      Min 5 characters. First character must be a letter. Must contain only letters, digits, '.', '-' or underscores.
-  RDSUsername:
+      Min 5 characters. First character must be a letter. Must contain only letters, digits or '-'.
+  NewRDSSubnets:
+    Description: Subnets to deploy the new RDS cluster into.  At least 2 must be entered, even when using existing
+          service.
+    Type: 'List<AWS::EC2::Subnet::Id>'
+    ConstraintDescription: Required
+  RDSUser:
     Description: >-
       Master user name for the RDS database. Min 5 characters. It can contain
       only alphanumeric characters and underscores.
@@ -207,11 +203,6 @@ Parameters:
     ConstraintDescription: >-
       Min 8 characters. Can contain only alphanumeric characters, minus and
       underscores.
-  RDSPort:
-    Description: RDS Port. Standards are 5432 for PostgreSQL and 1433 for Microsft SQL Server.
-    Type: Number
-    MinValue: '1024'
-    ConstraintDescription: Port number must be higher than 1024
   RDSName:
     Description: Repository database name in the RDS service.
     Type: String
@@ -222,24 +213,6 @@ Parameters:
     ConstraintDescription: >-
       Min 6 characters. Must begin with a letter and contain only alphanumeric
       characters and underscores.
-  ExistingFileSystemId:
-    Description: >-
-      For reusing an existing file system for Pyramid combined with an existing repository database.
-    Type: String
-    Default: ''
-    AllowedPattern: '^$|fs-[a-f0-9]{8}'
-    ConstraintDescription: >-
-      Optional. EFS ID like fs-9554b161.
-  InitializeRepository:
-    Description: If not restoring from backup, initialize Pyramid Repository database name. false assumes database name exists
-    Type: String
-    Default: true
-    AllowedValues:
-      - true
-      - false
-  RDSSecurityGroup:
-    Description: Security Group for access into RDS service.
-    Type: 'AWS::EC2::SecurityGroup::Id'
   InitialUsername:
     ConstraintDescription: >-
       Min 5 characters. Must begin with a letter and contain only alphanumeric
@@ -269,13 +242,6 @@ Parameters:
     Default: 200
     MinValue: 200
     ConstraintDescription: Must be more than 200 (MB).
-  CreateLoadBalancer:
-    Description: Create Load Balancer?
-    Type: String
-    Default: false
-    AllowedValues:
-      - true
-      - false
   LoadBalancerSubnets: 
     Description: Subnets for Load Balancer
     Type: 'List<AWS::EC2::Subnet::Id>'
@@ -291,6 +257,7 @@ Parameters:
     Description: 'Certificate Manager ARN for SSL certificate, of the form: arn:aws:acm:<region>:<AWS account id>:certificate/<certificate id GUID>'
     Type: String
     AllowedPattern: '^$|^arn:aws:acm:[a-z]{2}-[a-z]{4,}-\d{1,}:\d{12}:certificate/[-a-z0-9]{36}'
+
   BackupS3Bucket:
     Description: >-
       S3 bucket to a Pyramid backup
@@ -306,7 +273,7 @@ Parameters:
     Type: String
     Default: ''
     MaxLength: '1000'
-    AllowedPattern: '^$|^(?=^.{5,1000}$)[a-zA-Z0-9][-_a-zA-Z0-9\/\=()+]*$'
+    AllowedPattern: '^$|^(?=^.{5,1000}$)[a-zA-Z0-9][-_a-zA-Z0-9/\=()+]*$'
     ConstraintDescription: >-
       Optional. Otherwise min 5 characters. First character must be a letter or number. Must contain only letters, digits, '/', '-', '+', '_', '=' or parentheses.
 
@@ -358,6 +325,7 @@ Mappings:
     eu-south-1:
       '64': ami-015a7108facad1be3
 
+
 Rules:
   SubnetsNotEmpty:
     Assertions:
@@ -394,15 +362,10 @@ Conditions:
     - !Equals 
       - !Ref BackupS3Bucket
       - ''
-  DontInitializeRepository: !Or
-    - !Condition RestoreFromBackup
+  ImplementHTTPS: !Not
     - !Equals
-      - !Ref InitializeRepository
-      - 'false'
-  CreateLB: !Equals
-    - !Ref CreateLoadBalancer
-    - 'true'
-
+      - !Ref CertificateArn
+      - ''
 
 Resources:
 
@@ -419,19 +382,38 @@ Resources:
         AllowSSHSecurityGroup: !Ref AllowSSHSecurityGroup
         InitialUsername: !Ref InitialUsername
         InitialUserPassword: !Ref InitialUserPassword
-        ExistingFileSystemId: !If
-          - DontInitializeRepository
-          - !Ref ExistingFileSystemId
-          - !Ref AWS::NoValue
         FileUploadSize: !Ref FileUploadSize
+        ImplementLoadBalancer: true
+
+  CreateRepositoryDatabaseService:
+    Type: 'AWS::CloudFormation::Stack'
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    DependsOn: BaseResourcesParameters
+    Properties:
+      TemplateURL: >-
+        https://pyramid-cloudformation.s3.amazonaws.com/marketplace/2020-24-lb/pyramid-repository-database.yaml
+      Parameters:
+        BaseStackName: !Ref AWS::StackName
+        RDSDeploymentType: !Ref RDSDeploymentType
+        VPCID: !Ref VPCID
+        SubnetIds: !Join 
+          - ','
+          - !Ref NewRDSSubnets
+        DBServiceName: !Ref RDSServiceName
+        DBMasterUsername: !Ref RDSUser
+        DBMasterUserPassword: !Ref RDSPassword
 
   RepositoryDatabaseTypeSSM:
     Type: AWS::SSM::Parameter
-    DependsOn: BaseResourcesParameters
+    DependsOn: CreateRepositoryDatabaseService
     Properties:
       Name: !Sub '/Pyramid/${AWS::StackName}/RepositoryDatabaseType'
       Type: String
-      Value: !Ref RDSDeploymentType
+      Value: !If
+        - DatabaseTypeIsMicrosoft
+        - MicrosoftSQLServer
+        - PostgreSQL
       Description: Database type for repository in RDS
       Tags:
         StackName: !Sub '${AWS::StackName}'
@@ -439,11 +421,11 @@ Resources:
 
   RepositoryDatabaseServiceNameSSM:
     Type: AWS::SSM::Parameter
-    DependsOn: BaseResourcesParameters
+    DependsOn: CreateRepositoryDatabaseService
     Properties:
       Name: !Sub '/Pyramid/${AWS::StackName}/RepositoryDatabaseServiceName'
       Type: String
-      Value:  !Select [ 0, !Split [ ".", !Ref RDSAddress ]]
+      Value: !Ref RDSServiceName
       Description: RDS service name of repository
       Tags:
         StackName: !Sub '${AWS::StackName}'
@@ -454,7 +436,7 @@ Resources:
     Properties:
       Name: !Sub '/Pyramid/${AWS::StackName}/RepositoryDatabaseAddress'
       Type: String
-      Value: !Ref RDSAddress
+      Value: !GetAtt CreateRepositoryDatabaseService.Outputs.RDSEndPointAddress
       Description: RDS domain of repository
       Tags:
         StackName: !Sub '${AWS::StackName}'
@@ -465,7 +447,7 @@ Resources:
     Properties:
       Name: !Sub '/Pyramid/${AWS::StackName}/RepositoryDatabasePort'
       Type: String
-      Value: !Ref RDSPort
+      Value: !GetAtt CreateRepositoryDatabaseService.Outputs.RDSEndPointPort
       Description: Port for repository in RDS
       Tags:
         StackName: !Sub '${AWS::StackName}'
@@ -476,7 +458,7 @@ Resources:
     Properties:
       Name: !Sub '/Pyramid/${AWS::StackName}/RepositoryDatabaseUsername'
       Type: String
-      Value: !Ref RDSUsername
+      Value: !GetAtt CreateRepositoryDatabaseService.Outputs.DBMasterUsername
       Description: User name for repository in RDS
       Tags:
         StackName: !Sub '${AWS::StackName}'
@@ -484,7 +466,7 @@ Resources:
 
   RDSPasswordSecret:
     Type: 'AWS::SecretsManager::Secret'
-    DependsOn: BaseResourcesParameters
+    DependsOn: CreateRepositoryDatabaseService
     Properties:
       Name: !Sub '/Pyramid/${AWS::StackName}/RepositoryDatabasePassword'
       Description: Password for RDS service
@@ -510,7 +492,7 @@ Resources:
 
   RepositoryDatabaseNameSSM:
     Type: AWS::SSM::Parameter
-    DependsOn: BaseResourcesParameters
+    DependsOn: CreateRepositoryDatabaseService
     Properties:
       Name: !Sub '/Pyramid/${AWS::StackName}/RepositoryDatabaseName'
       Type: String
@@ -520,13 +502,24 @@ Resources:
         StackName: !Sub '${AWS::StackName}'
         Vendor: Pyramid
 
+  RepositoryDatabaseEncryptionKeyARNSSM:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub '/Pyramid/${AWS::StackName}/RepositoryDatabaseEncryptionKeyARN'
+      Type: String
+      Value: !GetAtt CreateRepositoryDatabaseService.Outputs.RDSEncryptionKeyARN
+      Description: Encryption key for Repository RDS Service
+      Tags:
+        StackName: !Sub '${AWS::StackName}'
+        Vendor: Pyramid
+
   PyramidProcessesSecurityGroupRepositoryAccess:
     Type: 'AWS::EC2::SecurityGroupIngress'
     Properties:
-      GroupId: !Ref RDSSecurityGroup
+      GroupId: !GetAtt CreateRepositoryDatabaseService.Outputs.RDSSecurityGroupId
       IpProtocol: tcp
-      FromPort: !Ref RDSPort
-      ToPort: !Ref RDSPort
+      FromPort: !GetAtt CreateRepositoryDatabaseService.Outputs.RDSEndPointPort
+      ToPort: !GetAtt CreateRepositoryDatabaseService.Outputs.RDSEndPointPort
       SourceSecurityGroupId: !GetAtt BaseResourcesParameters.Outputs.PyramidProcessesSecurityGroupId
 
   RestoreBackup:
@@ -569,7 +562,7 @@ Resources:
         AssignPublicIP: !Ref AssignPublicIP
         InstallProxy: true
         RepositoryType: !If
-          - DontInitializeRepository
+          - RestoreFromBackup
           - reuseremote
           - newremote
         #  Unused parameter. Only for dependency management in calling CFTs
@@ -578,18 +571,16 @@ Resources:
           - !GetAtt RestoreBackup.Outputs.BackupBucket
           - No backup
 
-
   LoadBalancer:
     Type: 'AWS::CloudFormation::Stack'
-    Condition: CreateLB
     Properties:
       TemplateURL: >-
         https://pyramid-cloudformation.s3.amazonaws.com/marketplace/2020-24-lb/pyramid-load-balancer.yaml
       Parameters:
         BaseStackName: !Ref AWS::StackName
-        WebInstance: !Ref CentralInstance
+        WebInstance: !GetAtt CentralInstance.Outputs.InstanceId
         VPCID: !Ref VPCID
-        LoadBalancerSubnetIds: !Join 
+        LoadBalancerSubnets: !Join 
           - ','
           - !Ref LoadBalancerSubnets
         LoadBalancerInternetFacing: !Ref LoadBalancerInternetFacing
@@ -597,28 +588,18 @@ Resources:
 
 Outputs:
   PyramidPublicURL:
-    Value: !If
-      - PublicIP
-      - !Join
-        - ''
-        - - 'http://'
-          - !GetAtt CentralInstance.Outputs.PublicDNSName
-      - 'No public URL'
-    Description: Pyramid Public URL
+    Value: !GetAtt LoadBalancer.Outputs.PyramidPublicURL
+    Description: Pyramid Public URL from load balancer
   PrivateDNSName:
-    Value: !GetAtt CentralInstance.Outputs.PrivateDNSName
-    Description: Instance Private DNS name
-  PublicDNSName:
-    Value: !GetAtt CentralInstance.Outputs.PublicDNSName
-    Description: Instance Public DNS name
-
+    Value: !GetAtt LoadBalancer.Outputs.PrivateDNSName
+    Description: Load balancer private DNS name
   VPC:
     Value: !Ref VPCID
     Description: VPC for deployment
   KeyPairName:
     Value: !Ref KeyPairName
     Description: Key Pair for instances
-    
+
   PyramidRole:
     Value: !GetAtt BaseResourcesParameters.Outputs.PyramidRole
     Description: IAM Role for instances launched from this stack
@@ -647,16 +628,16 @@ Outputs:
       - PostgreSQL
     Description: RDS Database type
   RepositoryDatabaseAddress:
-    Value: !Ref RDSAddress
+    Value: !GetAtt CreateRepositoryDatabaseService.Outputs.RDSEndPointAddress
     Description: Repository database address
   RepositoryDatabasePort:
-    Value: !Ref RDSPort
+    Value: !GetAtt CreateRepositoryDatabaseService.Outputs.RDSEndPointPort
     Description: Repository database port
   RepositoryDatabaseServiceName:
-    Value: !Select [ 0, !Split [ ".", !Ref RDSAddress ]]
+    Value: !Ref RDSServiceName
     Description: Repository database RDS Service name
   RepositoryDatabaseUsername:
-    Value: !Ref RDSUsername
+    Value: !Ref RDSUser
     Description: Repository database user name
   RepositoryDatabasePasswordARN:
     Value: !Ref RDSPasswordSecret
@@ -665,5 +646,8 @@ Outputs:
     Value: !Ref RDSName
     Description: Repository database schema name
   RDSSecurityGroup:
-    Value: !Ref RDSSecurityGroup
-    Description: Security Group access to repository database
+    Value: !GetAtt CreateRepositoryDatabaseService.Outputs.RDSSecurityGroup
+    Description: Security Group access to repository
+  RDSEncryptionKeyARN:
+    Value: !GetAtt CreateRepositoryDatabaseService.Outputs.RDSEncryptionKeyARN
+    Description: Repository database encryption key ARN

--- a/marketplace/pyramid-central-instance-new-repository.yaml
+++ b/marketplace/pyramid-central-instance-new-repository.yaml
@@ -30,13 +30,6 @@ Metadata:
           - RDSPassword
           - RDSName
       - Label:
-          default: New Load Balancer
-        Parameters:
-          - CreateLoadBalancer
-          - LoadBalancerSubnets
-          - LoadBalancerInternetFacing
-          - CertificateArn
-      - Label:
           default: Pyramid S3 backup to restore from
         Parameters:
           - BackupS3Bucket
@@ -75,14 +68,6 @@ Metadata:
         default: Initial Pyramid user name
       InitialUserPassword:
         default: Initial Pyramid User password
-      CreateLoadBalancer:
-        default: Create Load Balancer?
-      LoadBalancerSubnets: 
-        default: Subnets for Load Balancer
-      LoadBalancerInternetFacing:
-        default: Is the load balancer exposed to the public internet?
-      CertificateArn:
-        default: ARN for SSL certificate
       BackupS3Bucket:
         default: S3 bucket containing a Pyramid backup
       BackupS3Folder:
@@ -245,28 +230,6 @@ Parameters:
     Default: 200
     MinValue: 200
     ConstraintDescription: Must be more than 200 (MB).
-  CreateLoadBalancer:
-    Description: Create Load Balancer?
-    Type: String
-    Default: false
-    AllowedValues:
-      - true
-      - false
-  LoadBalancerSubnets: 
-    Description: Subnets for Load Balancer
-    Type: 'List<AWS::EC2::Subnet::Id>'
-  LoadBalancerInternetFacing:
-    Description: >-
-      Load Balancer is exposed to public Internet
-    Type: String
-    Default: true
-    AllowedValues:
-      - true
-      - false
-  CertificateArn:
-    Description: 'Certificate Manager ARN for SSL certificate, of the form: arn:aws:acm:<region>:<AWS account id>:certificate/<certificate id GUID>'
-    Type: String
-    AllowedPattern: '^$|^arn:aws:acm:[a-z]{2}-[a-z]{4,}-\d{1,}:\d{12}:certificate/[-a-z0-9]{36}'
 
   BackupS3Bucket:
     Description: >-
@@ -372,15 +335,6 @@ Conditions:
     - !Equals 
       - !Ref BackupS3Bucket
       - ''
-  CreateLB: !Equals
-    - !Ref CreateLoadBalancer
-    - 'true'
-  ImplementHTTPS: !And
-    - !Condition CreateLB
-    - !Not
-      - !Equals
-        - !Ref CertificateArn
-        - ''
 
 Resources:
 
@@ -398,13 +352,7 @@ Resources:
         InitialUsername: !Ref InitialUsername
         InitialUserPassword: !Ref InitialUserPassword
         FileUploadSize: !Ref FileUploadSize
-        ImplementLoadBalancer: !If
-          - CreateLB
-          - !If
-            - ImplementHTTPS
-            - trueHTTPS
-            - true 
-          - false
+        ImplementLoadBalancer: false
 
   CreateRepositoryDatabaseService:
     Type: 'AWS::CloudFormation::Stack'
@@ -591,22 +539,6 @@ Resources:
           - RestoreFromBackup
           - !GetAtt RestoreBackup.Outputs.BackupBucket
           - No backup
-
-  LoadBalancer:
-    Type: 'AWS::CloudFormation::Stack'
-    Condition: CreateLB
-    Properties:
-      TemplateURL: >-
-        https://pyramid-cloudformation.s3.amazonaws.com/marketplace/2020-24-lb/pyramid-load-balancer.yaml
-      Parameters:
-        BaseStackName: !Ref AWS::StackName
-        WebInstance: !GetAtt CentralInstance.Outputs.InstanceId
-        VPCID: !Ref VPCID
-        LoadBalancerSubnetIds: !Join 
-          - ','
-          - !Ref LoadBalancerSubnets
-        LoadBalancerInternetFacing: !Ref LoadBalancerInternetFacing
-        CertificateArn: !Ref CertificateArn
 
 Outputs:
   PyramidPublicURL:

--- a/marketplace/pyramid-central-instance-new-repository.yaml
+++ b/marketplace/pyramid-central-instance-new-repository.yaml
@@ -30,6 +30,13 @@ Metadata:
           - RDSPassword
           - RDSName
       - Label:
+          default: New Load Balancer
+        Parameters:
+          - CreateLoadBalancer
+          - LoadBalancerSubnets
+          - LoadBalancerInternetFacing
+          - CertificateArn
+      - Label:
           default: Pyramid S3 backup to restore from
         Parameters:
           - BackupS3Bucket
@@ -68,6 +75,14 @@ Metadata:
         default: Initial Pyramid user name
       InitialUserPassword:
         default: Initial Pyramid User password
+      CreateLoadBalancer:
+        default: Create Load Balancer?
+      LoadBalancerSubnets: 
+        default: Subnets for Load Balancer
+      LoadBalancerInternetFacing:
+        default: Is the load balancer exposed to the public internet?
+      CertificateArn:
+        default: ARN for SSL certificate
       BackupS3Bucket:
         default: S3 bucket containing a Pyramid backup
       BackupS3Folder:
@@ -230,6 +245,29 @@ Parameters:
     Default: 200
     MinValue: 200
     ConstraintDescription: Must be more than 200 (MB).
+  CreateLoadBalancer:
+    Description: Create Load Balancer?
+    Type: String
+    Default: false
+    AllowedValues:
+      - true
+      - false
+  LoadBalancerSubnets: 
+    Description: Subnets for Load Balancer
+    Type: 'List<AWS::EC2::Subnet::Id>'
+  LoadBalancerInternetFacing:
+    Description: >-
+      Load Balancer is exposed to public Internet
+    Type: String
+    Default: true
+    AllowedValues:
+      - true
+      - false
+  CertificateArn:
+    Description: 'Certificate Manager ARN for SSL certificate, of the form: arn:aws:acm:<region>:<AWS account id>:certificate/<certificate id GUID>'
+    Type: String
+    AllowedPattern: '^$|^arn:aws:acm:[a-z]{2}-[a-z]{4,}-\d{1,}:\d{12}:certificate/[-a-z0-9]{36}'
+
   BackupS3Bucket:
     Description: >-
       S3 bucket to a Pyramid backup
@@ -334,6 +372,15 @@ Conditions:
     - !Equals 
       - !Ref BackupS3Bucket
       - ''
+  CreateLB: !Equals
+    - !Ref CreateLoadBalancer
+    - 'true'
+  ImplementHTTPS: !And
+    - !Condition CreateLB
+    - !Not
+      - !Equals
+        - !Ref CertificateArn
+        - ''
 
 Resources:
 
@@ -341,7 +388,7 @@ Resources:
     Type: 'AWS::CloudFormation::Stack'
     Properties:
       TemplateURL: >-
-        https://pyramid-cloudformation.s3.amazonaws.com/marketplace/2020-24/pyramid-base-resources-parameters.yaml
+        https://pyramid-cloudformation.s3.amazonaws.com/marketplace/2020-24-lb/pyramid-base-resources-parameters.yaml
       Parameters:
         BaseStackName: !Ref AWS::StackName
         VPCID: !Ref VPCID
@@ -351,6 +398,13 @@ Resources:
         InitialUsername: !Ref InitialUsername
         InitialUserPassword: !Ref InitialUserPassword
         FileUploadSize: !Ref FileUploadSize
+        ImplementLoadBalancer: !If
+          - CreateLB
+          - !If
+            - ImplementHTTPS
+            - trueHTTPS
+            - true 
+          - false
 
   CreateRepositoryDatabaseService:
     Type: 'AWS::CloudFormation::Stack'
@@ -359,7 +413,7 @@ Resources:
     DependsOn: BaseResourcesParameters
     Properties:
       TemplateURL: >-
-        https://pyramid-cloudformation.s3.amazonaws.com/marketplace/2020-24/pyramid-repository-database.yaml
+        https://pyramid-cloudformation.s3.amazonaws.com/marketplace/2020-24-lb/pyramid-repository-database.yaml
       Parameters:
         BaseStackName: !Ref AWS::StackName
         RDSDeploymentType: !Ref RDSDeploymentType
@@ -496,7 +550,7 @@ Resources:
       - PyramidProcessesSecurityGroupRepositoryAccess
     Properties:
       TemplateURL: >-
-        https://pyramid-cloudformation.s3.amazonaws.com/marketplace/2020-24/pyramid-backup-restore-s3.yaml
+        https://pyramid-cloudformation.s3.amazonaws.com/marketplace/2020-24-lb/pyramid-backup-restore-s3.yaml
       Parameters:
         BackupRestore: restore
         BaseStackName: !Ref AWS::StackName
@@ -510,7 +564,7 @@ Resources:
       - PyramidProcessesSecurityGroupRepositoryAccess
     Properties:
       TemplateURL: >-
-        https://pyramid-cloudformation.s3.amazonaws.com/marketplace/2020-24/pyramid-single-instance.yaml
+        https://pyramid-cloudformation.s3.amazonaws.com/marketplace/2020-24-lb/pyramid-single-instance.yaml
       Parameters:
         AMIID: !FindInMap 
           - AWSAMIRegionMap
@@ -537,6 +591,22 @@ Resources:
           - RestoreFromBackup
           - !GetAtt RestoreBackup.Outputs.BackupBucket
           - No backup
+
+  LoadBalancer:
+    Type: 'AWS::CloudFormation::Stack'
+    Condition: CreateLB
+    Properties:
+      TemplateURL: >-
+        https://pyramid-cloudformation.s3.amazonaws.com/marketplace/2020-24-lb/pyramid-load-balancer.yaml
+      Parameters:
+        BaseStackName: !Ref AWS::StackName
+        WebInstance: !GetAtt CentralInstance.Outputs.InstanceId
+        VPCID: !Ref VPCID
+        LoadBalancerSubnetIds: !Join 
+          - ','
+          - !Ref LoadBalancerSubnets
+        LoadBalancerInternetFacing: !Ref LoadBalancerInternetFacing
+        CertificateArn: !Ref CertificateArn
 
 Outputs:
   PyramidPublicURL:

--- a/marketplace/pyramid-load-balancer-with-auto-scaled-instances.yaml
+++ b/marketplace/pyramid-load-balancer-with-auto-scaled-instances.yaml
@@ -368,7 +368,7 @@ Resources:
     Type: 'AWS::CloudFormation::Stack'
     Properties:
       TemplateURL: >-
-        https://pyramid-cloudformation.s3.amazonaws.com/marketplace/2020-24/pyramid-autoscale-instances.yaml
+        https://pyramid-cloudformation.s3.amazonaws.com/marketplace/2020-24-lb/pyramid-autoscale-instances.yaml
       Parameters:
         BaseStackName: !Ref BaseStackName
         PyramidProcess: EverythingExceptInMemoryDB

--- a/marketplace/pyramid-load-balancer.yaml
+++ b/marketplace/pyramid-load-balancer.yaml
@@ -351,12 +351,13 @@ Outputs:
         - !GetAtt 
           - ElasticLoadBalancer
           - DNSName
-    Description: Pyramid Public URL
-  PublicDNSName:
+    Description: Pyramid Public URL through load balancer
+  PrivateDNSName:
     Value: !GetAtt 
           - ElasticLoadBalancer
           - DNSName
-    Description: Instance Public DNS name
+    Description: Load balancer private DNS name
   VPC:
     Value: !Ref VPCID
     Description: VPC for deployment
+

--- a/marketplace/pyramid-load-balancer.yaml
+++ b/marketplace/pyramid-load-balancer.yaml
@@ -1,0 +1,362 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: >-
+  This workload template deploys an Application Load Balancer, 2 (Everything - IMDB)
+  instances and an IMDB instance. Because we are launching from AWS Marketplace AMIs,
+  which are limited to Standard Edition, we need to launch from a Central instance that
+  has had an Enterprise license deployed to it.
+
+  Central instance first, then run this template to add on.
+  Kill Central instance. What if there are add on instances?
+  Copy Resoources, SSM and Secrets?
+
+  Nah! need a way to add the license in as part of the initialization of the cluster!
+
+  2 Everything - IMDB: auto-scaled, ALB
+  1 IMDB
+
+  Am able to restore a backup on creation.
+
+  **WARNING** This template creates EC2 instances and related
+  resources. You will be billed for the AWS resources used if you create a stack
+  from this template. (qs-1puat849f)
+Metadata:
+  'AWS::CloudFormation::Interface':
+    ParameterGroups:
+      - Label:
+          default: Common instance configuration
+        Parameters:
+          - BaseStackName
+          - WebInstance
+      - Label:
+          default: Load Balancer configuration
+        Parameters:
+          - VPCID
+          - LoadBalancerSubnets
+          - LoadBalancerInternetFacing
+          - LoadBalancerPublic
+          - CertificateArn
+    ParameterLabels:
+      BaseStackName:
+        default: CloudFormation stack to attach to
+      VPCID:
+        default: VPC ID
+      WebInstance:
+        default: Instance Id to add into the load balancer
+      LoadBalancerSubnets:
+        default: Load balancer subnets
+      LoadBalancerPublic:
+        default: Load Balancer Available on Public Internet?
+      LoadBalancerInternetFacing:
+        default: Is the load balancer exposed to the public internet?
+      CertificateArn:
+        default: ARN of cerificate for HTTPS
+
+Parameters:
+  BaseStackName:
+    Description: Base StackName this stack is a part of
+    Type: String
+    MinLength: '1'
+    MaxLength: '32'
+    AllowedPattern: '[-_a-zA-Z0-9]*'
+    ConstraintDescription: Required
+  WebInstance:
+    Description: Instance Id to add into the load balancer
+    Type: String
+    MinLength: '19'
+    MaxLength: '19'
+    AllowedPattern: 'i-[a-f0-9]{17}'
+    ConstraintDescription: Required
+    # i-0e0b874783b89a4d9
+  VPCID:
+    Description: ID of your existing VPC for deployment.
+    Type: 'AWS::EC2::VPC::Id'
+    ConstraintDescription: Required
+  LoadBalancerSubnets:
+    Description: >-
+      Subnets for load balancer
+    Type: CommaDelimitedList
+  LoadBalancerInternetFacing:
+    Description: >-
+      Load Balancer is exposed to public Internet
+    Type: String
+    Default: true
+    AllowedValues:
+      - true
+      - false
+    ConstraintDescription: Required
+  CertificateArn:
+    Description: >-
+      (Optional) ARN of cerificate for HTTPS
+    Type: String
+
+Rules:
+  SubnetsInVPC:
+    Assertions:
+      - Assert:
+          'Fn::EachMemberIn':
+            - 'Fn::ValueOfAll':
+                - 'AWS::EC2::Subnet::Id'
+                - VpcId
+            - 'Fn::RefAll': 'AWS::EC2::VPC::Id'
+        AssertDescription: All subnets must in the same VPC
+Conditions:
+  LoadBalancerIsInternet: !Equals
+    - !Ref LoadBalancerInternetFacing
+    - 'true'
+  ImplementHTTPS: !Not
+    - !Equals
+      - !Ref CertificateArn
+      - ''
+  HTTPOnly: !Equals
+    - !Ref CertificateArn
+    - ''
+
+Resources:
+
+  ElasticLoadBalancer:
+    Type: 'AWS::ElasticLoadBalancingV2::LoadBalancer'
+    Properties:
+      Subnets: !Ref LoadBalancerSubnets
+      SecurityGroups:
+        - !Sub '{{resolve:ssm:/Pyramid/${BaseStackName}/LoadBalancerAccessSecurityGroup:1}}'
+      Type: application
+      Scheme: !If
+        - LoadBalancerIsInternet
+        - 'internet-facing' 
+        - 'internal'
+      LoadBalancerAttributes:
+        - Key: idle_timeout.timeout_seconds
+          Value: '600'
+
+  ELBTargetGroup:
+    Type: 'AWS::ElasticLoadBalancingV2::TargetGroup'
+    # DependsOn: ElasticLoadBalancer
+    Properties:
+      HealthCheckIntervalSeconds: 90
+      HealthCheckPath: /
+      HealthCheckPort: 80
+      HealthCheckProtocol: HTTP
+      HealthCheckTimeoutSeconds: 15
+      HealthyThresholdCount: 2
+      UnhealthyThresholdCount: 10
+      Matcher:
+        HttpCode: '200,302'
+      Port: 80
+      Protocol: HTTP
+      TargetType: instance
+      Targets:
+      - Id: !Ref WebInstance
+      VpcId: !Ref VPCID
+
+  HTTPOnlyListener:
+    Type: 'AWS::ElasticLoadBalancingV2::Listener'
+    Condition: HTTPOnly
+    Properties:
+      LoadBalancerArn: !Ref ElasticLoadBalancer
+      Port: 80
+      Protocol: HTTP
+      DefaultActions:
+        - Type: forward
+          TargetGroupArn: !Ref ELBTargetGroup
+
+
+  HTTPToHTTPSListener:
+    Type: 'AWS::ElasticLoadBalancingV2::Listener'
+    Condition: ImplementHTTPS
+    Properties:
+      LoadBalancerArn: !Ref ElasticLoadBalancer
+      Port: 80
+      Protocol: HTTP
+      DefaultActions:
+        - Type: redirect
+          RedirectConfig:
+            Protocol: HTTPS
+            Port: 443
+            Host: '#{host}'
+            Path:  '/#{path}'
+            Query: '#{query}'
+            StatusCode: 'HTTP_301'
+
+  HTTPSListener:
+      Type: "AWS::ElasticLoadBalancingV2::Listener"
+      Condition: ImplementHTTPS
+      Properties:
+          LoadBalancerArn: !Ref ElasticLoadBalancer
+          Port: 443
+          Protocol: HTTPS
+          SslPolicy: "ELBSecurityPolicy-2016-08"
+          Certificates: 
+            - 
+              CertificateArn:  !Ref CertificateArn
+          # arn:aws:acm:***AWS region***:**************:certificate/*********************
+              
+          DefaultActions: 
+            - 
+              Order: 1
+              TargetGroupArn: !Ref ELBTargetGroup
+              Type: "forward"
+
+  # WebEngineIngress:
+  #   Type: 'AWS::EC2::SecurityGroupIngress'
+  #   Properties:
+  #     GroupId: !GetAtt
+  #       - !Sub '{{resolve:ssm:/Pyramid/${BaseStackName}/PyramidProcessesSecurityGroup:1}}'
+  #       - GroupId
+  #     IpProtocol: tcp
+  #     FromPort: 80
+  #     ToPort: 80
+  #     SourceSecurityGroupId: !Sub '{{resolve:ssm:/Pyramid/${BaseStackName}/WebAccessSecurityGroup:1}}'
+
+
+  LoadBalancerSSM:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub '/Pyramid/${BaseStackName}/LoadBalancer'
+      Type: String
+      Value: !Ref ElasticLoadBalancer
+      Description: Load balancer ARN
+      Tags:
+        StackName: !Ref BaseStackName
+        Vendor: Pyramid
+
+  WebTargetGroupSSM:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub '/Pyramid/${BaseStackName}/WebTargetGroup'
+      Type: String
+      Value: !Ref ELBTargetGroup
+      Description: Target group for web server instances
+      Tags:
+        StackName: !Ref BaseStackName
+        Vendor: Pyramid
+
+  ManageTargetsRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      ManagedPolicyArns:
+        - !Sub >-
+          arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - 'sts:AssumeRole'
+      Policies:
+        - PolicyName: ManageTargetsPolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: ManageTargetsPolicy
+                Effect: Allow
+                Action:
+                  - 'elasticloadbalancing:RegisterTargets'
+                  - 'ec2:DescribeInstances'
+                  - 'ec2:DescribeInternetGateways'
+                  - 'ec2:DescribeSubnets'
+                  - 'ec2:DescribeVpcs'
+                Resource:
+                  - !Ref ELBTargetGroup
+                  # - !Sub >-
+                  #   arn:${AWS::Partition}:elasticloadbalancing:${AWS::Region}:${AWS::AccountId}:targetgroup/${ExistingFileSystemId}
+# arn:aws:elasticloadbalancing:us-east-1:343272018671:targetgroup/palo-reganalytics/c3a7a68961bc07c0
+
+  ManageTargetsLambda:
+    Type: 'AWS::Lambda::Function'
+    Properties:
+      Code:
+        ZipFile: |
+          import boto3
+          import json
+          import cfnresponse
+          from botocore.exceptions import ClientError
+
+          def add_instance_to_target_group(event, _):
+              
+              targetGroupArn = event['ResourceProperties']['TargetGroupArn']
+              ec2InstanceId = event['ResourceProperties']['InstanceId']
+              
+              client = boto3.client('elbv2')
+
+              # # get existing targets
+
+              # response = client.describe_target_health(
+              #     TargetGroupArn=targetGroupArn,
+              # )
+              try:
+                  response = client.register_targets(
+                      TargetGroupArn = targetGroupArn,
+                      Targets=[
+                          {
+                              'Id': ec2InstanceId,
+                          },
+                      ]
+                  )
+
+                  return {
+                      "Status" : True,
+                      "Message" : response
+                  }
+
+              except ClientError as e:
+                  print(e)
+                  return {
+                        "Status" : False,
+                        "Message" :  e.response['Error']['Message']
+                  }
+
+          def handler(event, context):
+              print(event)
+              answer={}
+              if event.get("RequestType") == "Delete":
+                  cfnresponse.send(event, context, cfnresponse.SUCCESS, responseData=answer)
+              else:
+                  answer = add_instance_to_target_group(event, context)
+                  if answer["Status"] == True:
+                      responseStatus = cfnresponse.SUCCESS
+                  else:
+                      responseStatus = cfnresponse.FAILED
+                  cfnresponse.send(event, context, responseStatus, responseData=answer)
+
+
+      Runtime: python3.7
+      Handler: index.handler
+      Role: !GetAtt ManageTargetsRole.Arn
+
+
+  ManageTargetsLambdaArnSSM:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub '/Pyramid/${BaseStackName}/ManageTargetsLambdaArn'
+      Type: String
+      Value: !GetAtt ManageTargetsLambda.Arn
+      Description: ARN pof Lambda to manage target group instances
+      Tags:
+        StackName: !Ref BaseStackName
+        Vendor: Pyramid
+
+Outputs:
+  PyramidPublicURL:
+    Value: !Join 
+      - ''
+      - - 'http'
+        - !If
+          - ImplementHTTPS
+          - 's' 
+          - ''
+        - '://'
+        - !GetAtt 
+          - ElasticLoadBalancer
+          - DNSName
+    Description: Pyramid Public URL
+  PublicDNSName:
+    Value: !GetAtt 
+          - ElasticLoadBalancer
+          - DNSName
+    Description: Instance Public DNS name
+  VPC:
+    Value: !Ref VPCID
+    Description: VPC for deployment

--- a/marketplace/pyramid-repository-database.yaml
+++ b/marketplace/pyramid-repository-database.yaml
@@ -148,22 +148,25 @@ Mappings:
   DBConfiguration:
     PostgreSQLAuroraServerless:
       engine: aurora-postgresql
+      engineMode: serverless
       licenseModel: no explicit license
       instanceClass: no instance type
       port: '5432'
     PostgreSQLAuroraProvisioned:
       engine: aurora-postgresql
+      engineMode: provisioned
       licenseModel: no explicit license
       instanceClass: db.r5.xlarge
       port: '5432'
     PostgreSQL:
       engine: postgres
+      engineMode: provisioned
       licenseModel: no explicit license
       instanceClass: db.r5.xlarge
       port: '5432'
     MicrosoftSQLServer:
       engine: sqlserver-se
-      version: no instance version
+      engineMode: provisioned
       licenseModel: license-included
       instanceClass: db.r5.xlarge
       port: '1433'
@@ -229,12 +232,20 @@ Resources:
               # find the default engine version of the given engine
               
               engine = event['ResourceProperties']['Engine']
+              engine_mode = event['ResourceProperties']['EngineMode']
               region = event['ResourceProperties']['Region']
               
-              client = boto3.client('rds')
+              client = boto3.client('rds', region_name=region)
               
               try:
-                  default_engine_version = client.describe_db_engine_versions(Engine=engine, DefaultOnly=True)
+                  default_engine_version = client.describe_db_engine_versions(Engine=engine, DefaultOnly=True, Filters=[
+                      {
+                          'Name': 'engine-mode',
+                          'Values': [
+                              engine_mode,
+                          ]
+                      },
+                  ])
               except ClientError as e:
                   print(e)
                   return {
@@ -267,6 +278,7 @@ Resources:
               status = cfnresponse.SUCCESS
               if event.get("RequestType") != "Delete":
                   answer = get_default_engine_version(event, context)
+                  print(answer)
                   if answer['Status'] == False:
                       status = cfnresponse.FAILED
               cfnresponse.send(event, context, status, responseData=answer)
@@ -306,6 +318,7 @@ Resources:
     Properties:
       ServiceToken: !GetAtt DBEngineVersion.Arn
       Engine: !FindInMap [DBConfiguration, !Ref RDSDeploymentType, "engine"]
+      EngineMode: !FindInMap [DBConfiguration, !Ref RDSDeploymentType, "engineMode"]
       Region: !Ref 'AWS::Region'
 
 
@@ -374,10 +387,8 @@ Resources:
         - !Ref RDSSecurityGroup
       DBClusterIdentifier: !Ref DBServiceName
       Engine: !FindInMap [DBConfiguration, !Ref RDSDeploymentType, "engine"]
-      EngineMode: !If 
-        - PostgreSQLAuroraServerless
-        - serverless
-        - provisioned
+      EngineVersion: !GetAtt GetDBEngineVersion.EngineVersion
+      EngineMode: !FindInMap [DBConfiguration, !Ref RDSDeploymentType, "engineMode"]
       MasterUserPassword: !Ref DBMasterUserPassword
       MasterUsername: !Ref DBMasterUsername
       Port: !FindInMap [DBConfiguration, !Ref RDSDeploymentType, "port"]
@@ -400,6 +411,7 @@ Resources:
         - !Ref DBInstanceClass
         - !FindInMap [DBConfiguration, !Ref RDSDeploymentType, "instanceClass"]
       Engine: !FindInMap [DBConfiguration, !Ref RDSDeploymentType, "engine"]
+      EngineVersion: !GetAtt GetDBEngineVersion.EngineVersion
       LicenseModel: !If
         - SQLServer
         - !FindInMap [DBConfiguration, !Ref RDSDeploymentType, "licenseModel"]

--- a/marketplace/pyramid-single-instance.yaml
+++ b/marketplace/pyramid-single-instance.yaml
@@ -586,6 +586,9 @@ Outputs:
   PrivateDNSName:
     Value: !GetAtt PyramidInstance.PrivateDnsName
     Description: Instance Private DNS name
+  InstanceId:
+    Value: !Ref PyramidInstance
+    Description: Created Instance Id
 
 
   DependencyValue:


### PR DESCRIPTION
Adding load balancer options for the central deployment.

The central instance - new repository and add to central instance remain the CFTs used from the Marketplace.

Also auto detect the default database engine versions when creating or backup/restoring the repository database.